### PR TITLE
Fix author tag

### DIFF
--- a/man/pmmlparty.Rd
+++ b/man/pmmlparty.Rd
@@ -22,7 +22,7 @@ An object of class pmml
 \description{
 Generate the PMML representation for a party object from package party and partykit
 }
-\author {
+\author{
 Seheon Kim
 }
 \details{


### PR DESCRIPTION
Installing the package in R 4.0.4 failed with the following error:

D:/Temp/RtmpKaF65O/R.INSTALL34a05d804278/pmmlParty/man/pmmlparty.Rd:25: unexpected TEXT ' ', expecting '{'

removing the space between `\author` and `}` fixed the error